### PR TITLE
Additional aggregation options: EMPTY and BUCKETTIMESTAMP

### DIFF
--- a/src/async_commands.rs
+++ b/src/async_commands.rs
@@ -330,6 +330,7 @@ pub trait AsyncTsCommands: ConnectionLike + Send + Sized {
         C: ToRedisArgs + Send + Sync + 'a,
         TS: std::marker::Copy + FromRedisValue,
         V: std::marker::Copy + FromRedisValue,
+        AGG: Aggregatable + ToRedisArgs + Send + 'a,
     >(
         &'a mut self,
         command: &str,
@@ -337,7 +338,8 @@ pub trait AsyncTsCommands: ConnectionLike + Send + Sized {
         from_timestamp: FTS,
         to_timestamp: TTS,
         count: Option<C>,
-        aggregation_type: Option<TsAggregationType>,
+        aggregation_type: Option<AGG
+        >,
     ) -> RedisFuture<TsRange<TS, V>> {
         let mut c = cmd(command);
         c.arg(key).arg(from_timestamp).arg(to_timestamp);
@@ -356,13 +358,14 @@ pub trait AsyncTsCommands: ConnectionLike + Send + Sized {
         C: ToRedisArgs + Send + Sync + 'a,
         TS: std::marker::Copy + FromRedisValue,
         V: std::marker::Copy + FromRedisValue,
+        AGG: Aggregatable + ToRedisArgs + Send + 'a,
     >(
         &'a mut self,
         key: K,
         from_timestamp: FTS,
         to_timestamp: TTS,
         count: Option<C>,
-        aggregation_type: Option<TsAggregationType>,
+        aggregation_type: Option<AGG>,
     ) -> RedisFuture<TsRange<TS, V>> {
         self.range(
             "TS.RANGE",
@@ -383,13 +386,14 @@ pub trait AsyncTsCommands: ConnectionLike + Send + Sized {
         C: ToRedisArgs + Send + Sync + 'a,
         TS: std::marker::Copy + FromRedisValue,
         V: std::marker::Copy + FromRedisValue,
+        AGG: Aggregatable + ToRedisArgs + Send + 'a,
     >(
         &'a mut self,
         key: K,
         from_timestamp: FTS,
         to_timestamp: TTS,
         count: Option<C>,
-        aggregation_type: Option<TsAggregationType>,
+        aggregation_type: Option<AGG>,
     ) -> RedisFuture<TsRange<TS, V>> {
         self.range(
             "TS.REVRANGE",
@@ -409,13 +413,14 @@ pub trait AsyncTsCommands: ConnectionLike + Send + Sized {
         C: ToRedisArgs + Send + Sync + 'a,
         TS: std::default::Default + FromRedisValue + Copy,
         V: std::default::Default + FromRedisValue + Copy,
+        AGG: Aggregatable + ToRedisArgs + Send,
     >(
         &mut self,
         command: &str,
         from_timestamp: FTS,
         to_timestamp: TTS,
         count: Option<C>,
-        aggregation_type: Option<TsAggregationType>,
+        aggregation_type: Option<AGG>,
         filter_options: TsFilterOptions,
     ) -> RedisFuture<TsMrange<TS, V>> {
         let mut c = cmd(command);
@@ -435,12 +440,13 @@ pub trait AsyncTsCommands: ConnectionLike + Send + Sized {
         C: ToRedisArgs + Send + Sync + 'a,
         TS: std::default::Default + FromRedisValue + Copy,
         V: std::default::Default + FromRedisValue + Copy,
+        AGG: Aggregatable + ToRedisArgs + Send,
     >(
         &mut self,
         from_timestamp: FTS,
         to_timestamp: TTS,
         count: Option<C>,
-        aggregation_type: Option<TsAggregationType>,
+        aggregation_type: Option<AGG>,
         filter_options: TsFilterOptions,
     ) -> RedisFuture<TsMrange<TS, V>> {
         self.mrange(
@@ -461,12 +467,13 @@ pub trait AsyncTsCommands: ConnectionLike + Send + Sized {
         C: ToRedisArgs + Send + Sync + 'a,
         TS: std::default::Default + FromRedisValue + Copy,
         V: std::default::Default + FromRedisValue + Copy,
+        AGG: Aggregatable + ToRedisArgs + Send,
     >(
         &mut self,
         from_timestamp: FTS,
         to_timestamp: TTS,
         count: Option<C>,
-        aggregation_type: Option<TsAggregationType>,
+        aggregation_type: Option<AGG>,
         filter_options: TsFilterOptions,
     ) -> RedisFuture<TsMrange<TS, V>> {
         self.mrange(

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -203,7 +203,7 @@ pub trait TsCommands: ConnectionLike + Sized {
         C: ToRedisArgs,
         TS: std::marker::Copy + FromRedisValue,
         V: std::marker::Copy + FromRedisValue,
-        AGG: Aggregateable + ToRedisArgs
+        AGG: Aggregatable + ToRedisArgs
     >(
         &mut self,
         command: &str,
@@ -229,7 +229,7 @@ pub trait TsCommands: ConnectionLike + Sized {
         C: ToRedisArgs,
         TS: std::marker::Copy + FromRedisValue,
         V: std::marker::Copy + FromRedisValue,
-        AGG: Aggregateable + ToRedisArgs
+        AGG: Aggregatable + ToRedisArgs
     >(
         &mut self,
         key: K,
@@ -256,7 +256,7 @@ pub trait TsCommands: ConnectionLike + Sized {
         C: ToRedisArgs,
         TS: std::marker::Copy + FromRedisValue,
         V: std::marker::Copy + FromRedisValue,
-        AGG: Aggregateable + ToRedisArgs
+        AGG: Aggregatable + ToRedisArgs
     >(
         &mut self,
         key: K,
@@ -282,7 +282,7 @@ pub trait TsCommands: ConnectionLike + Sized {
         C: ToRedisArgs,
         TS: std::default::Default + FromRedisValue + Copy,
         V: std::default::Default + FromRedisValue + Copy,
-        AGG: Aggregateable + ToRedisArgs
+        AGG: Aggregatable + ToRedisArgs
     >(
         &mut self,
         command: &str,
@@ -308,7 +308,7 @@ pub trait TsCommands: ConnectionLike + Sized {
         C: ToRedisArgs,
         TS: std::default::Default + FromRedisValue + Copy,
         V: std::default::Default + FromRedisValue + Copy,
-        AGG: Aggregateable + ToRedisArgs
+        AGG: Aggregatable + ToRedisArgs
     >(
         &mut self,
         from_timestamp: FTS,
@@ -334,7 +334,7 @@ pub trait TsCommands: ConnectionLike + Sized {
         C: ToRedisArgs,
         TS: std::default::Default + FromRedisValue + Copy,
         V: std::default::Default + FromRedisValue + Copy,
-        AGG: Aggregateable + ToRedisArgs
+        AGG: Aggregatable + ToRedisArgs
     >(
         &mut self,
         from_timestamp: FTS,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -203,6 +203,7 @@ pub trait TsCommands: ConnectionLike + Sized {
         C: ToRedisArgs,
         TS: std::marker::Copy + FromRedisValue,
         V: std::marker::Copy + FromRedisValue,
+        AGG: Aggregateable + ToRedisArgs
     >(
         &mut self,
         command: &str,
@@ -210,7 +211,7 @@ pub trait TsCommands: ConnectionLike + Sized {
         from_timestamp: FTS,
         to_timestamp: TTS,
         count: Option<C>,
-        aggregation_type: Option<TsAggregationType>,
+        aggregation_type: Option<AGG>,
     ) -> RedisResult<TsRange<TS, V>> {
         let mut c = cmd(command);
         c.arg(key).arg(from_timestamp).arg(to_timestamp);
@@ -228,13 +229,14 @@ pub trait TsCommands: ConnectionLike + Sized {
         C: ToRedisArgs,
         TS: std::marker::Copy + FromRedisValue,
         V: std::marker::Copy + FromRedisValue,
+        AGG: Aggregateable + ToRedisArgs
     >(
         &mut self,
         key: K,
         from_timestamp: FTS,
         to_timestamp: TTS,
         count: Option<C>,
-        aggregation_type: Option<TsAggregationType>,
+        aggregation_type: Option<AGG>,
     ) -> RedisResult<TsRange<TS, V>> {
         self.range(
             "TS.RANGE",
@@ -254,13 +256,14 @@ pub trait TsCommands: ConnectionLike + Sized {
         C: ToRedisArgs,
         TS: std::marker::Copy + FromRedisValue,
         V: std::marker::Copy + FromRedisValue,
+        AGG: Aggregateable + ToRedisArgs
     >(
         &mut self,
         key: K,
         from_timestamp: FTS,
         to_timestamp: TTS,
         count: Option<C>,
-        aggregation_type: Option<TsAggregationType>,
+        aggregation_type: Option<AGG>,
     ) -> RedisResult<TsRange<TS, V>> {
         self.range(
             "TS.REVRANGE",
@@ -279,13 +282,14 @@ pub trait TsCommands: ConnectionLike + Sized {
         C: ToRedisArgs,
         TS: std::default::Default + FromRedisValue + Copy,
         V: std::default::Default + FromRedisValue + Copy,
+        AGG: Aggregateable + ToRedisArgs
     >(
         &mut self,
         command: &str,
         from_timestamp: FTS,
         to_timestamp: TTS,
         count: Option<C>,
-        aggregation_type: Option<TsAggregationType>,
+        aggregation_type: Option<AGG>,
         filter_options: TsFilterOptions,
     ) -> RedisResult<TsMrange<TS, V>> {
         let mut c = cmd(command);
@@ -304,12 +308,13 @@ pub trait TsCommands: ConnectionLike + Sized {
         C: ToRedisArgs,
         TS: std::default::Default + FromRedisValue + Copy,
         V: std::default::Default + FromRedisValue + Copy,
+        AGG: Aggregateable + ToRedisArgs
     >(
         &mut self,
         from_timestamp: FTS,
         to_timestamp: TTS,
         count: Option<C>,
-        aggregation_type: Option<TsAggregationType>,
+        aggregation_type: Option<AGG>,
         filter_options: TsFilterOptions,
     ) -> RedisResult<TsMrange<TS, V>> {
         self.mrange(
@@ -329,12 +334,13 @@ pub trait TsCommands: ConnectionLike + Sized {
         C: ToRedisArgs,
         TS: std::default::Default + FromRedisValue + Copy,
         V: std::default::Default + FromRedisValue + Copy,
+        AGG: Aggregateable + ToRedisArgs
     >(
         &mut self,
         from_timestamp: FTS,
         to_timestamp: TTS,
         count: Option<C>,
-        aggregation_type: Option<TsAggregationType>,
+        aggregation_type: Option<AGG>,
         filter_options: TsFilterOptions,
     ) -> RedisResult<TsMrange<TS, V>> {
         self.mrange(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,11 +247,11 @@
 //! )?;
 //!
 //! let range_raw:TsRange<u64,f64> = con.ts_range(
-//!     "my_engine", 1234, 5678, None::<usize>, None
+//!     "my_engine", 1234, 5678, None::<usize>, None::<TsAggregationType>
 //! )?;
 //!
 //! let rev_range_raw:TsRange<u64,f64> = con.ts_revrange(
-//!     "my_engine", 1234, 5678, None::<usize>, None
+//!     "my_engine", 1234, 5678, None::<usize>, None::<TsAggregationType>
 //! )?;
 //! # Ok(()) }
 //! ```
@@ -271,12 +271,12 @@
 //! )?;
 //!
 //! let range_raw:TsMrange<u64,f64> = con.ts_mrange(
-//!     1234, 5678, None::<usize>, None,
+//!     1234, 5678, None::<usize>, None::<TsAggregationType>,
 //!     TsFilterOptions::default().equals("sensor", "temperature")
 //! )?;
 //!
 //! let rev_range_raw:TsMrange<u64,f64> = con.ts_mrevrange(
-//!     1234, 5678, None::<usize>, None,
+//!     1234, 5678, None::<usize>, None::<TsAggregationType>,
 //!     TsFilterOptions::default().equals("sensor", "temperature")
 //! )?;
 //! # Ok(()) }
@@ -344,8 +344,8 @@ pub use crate::async_commands::AsyncTsCommands;
 pub use crate::commands::TsCommands;
 
 pub use crate::types::{
-    TsAggregationType, TsDuplicatePolicy, TsFilterOptions, TsInfo, TsMget, TsMrange, TsOptions,
-    TsRange,
+    TsAggregationType, TsAggregationOptions, TsDuplicatePolicy, TsFilterOptions, TsInfo, TsMget, TsMrange, TsOptions,
+    TsRange, TsBucketTimestamp
 };
 
 #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]

--- a/src/types.rs
+++ b/src/types.rs
@@ -122,10 +122,10 @@ impl ToRedisArgs for TsAggregationOptions {
 }
 
 // a trait to allow both TsAggregationType and TsAggregationOptions to be passed as aggregation options
-pub trait Aggregateable {}
+pub trait Aggregatable {}
 
-impl Aggregateable for TsAggregationType {}
-impl Aggregateable for TsAggregationOptions {}
+impl Aggregatable for TsAggregationType {}
+impl Aggregatable for TsAggregationOptions {}
 
 
 /// Different options for handling inserts of duplicate values. Block

--- a/src/types.rs
+++ b/src/types.rs
@@ -48,9 +48,89 @@ impl ToRedisArgs for TsAggregationType {
     }
 }
 
+// since RedisTimeSeries v1.8, controls how bucket timestamps are reported.
+// low - the bucket's start time (default)
+// high - the bucket's end time
+// mid - the bucket's mid time (rounded down if not an integer)
+pub enum TsBucketTimestamp {
+    Low,
+    High,
+    Mid,
+}
+
+impl ToRedisArgs for TsBucketTimestamp {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        out.write_arg(b"BUCKETTIMESTAMP");
+        let bt = match *self {
+            TsBucketTimestamp::Low => "-",  // alternatively "low"
+            TsBucketTimestamp::High => "+", // alternatively "high"
+            TsBucketTimestamp::Mid => "~",  // alternatively "mid"
+        };
+
+        out.write_arg(bt.as_bytes());
+    }
+}
+// Different options for aggregation in addition to the aggregator type and bucket duration,
+// (since RedisTimeSeries v1.8) bucket_timestamp - controls how bucket timestamps are reported, see above
+// (since RedisTimeSeries v1.8) empty - a flag, which, when specified, reports aggregations also for empty buckets
+pub struct TsAggregationOptions {
+    aggregator: TsAggregationType,
+    bucket_timestamp: Option<TsBucketTimestamp>,
+    empty: bool,
+}
+
+impl TsAggregationOptions {
+    pub fn new(aggregator: TsAggregationType) -> TsAggregationOptions {
+        TsAggregationOptions {
+            aggregator: aggregator,
+            bucket_timestamp: None,
+            empty: false,
+        }
+    }
+
+    /// Sets empty aggregation flag
+    pub fn empty(mut self, value: bool) -> Self {
+        self.empty = value;
+        self
+    }
+
+    /// Sets aggregation bucket timestamp type
+    pub fn bucket_timestamp(mut self, value: Option<TsBucketTimestamp>) -> Self {
+        self.bucket_timestamp = value;
+        self
+    }
+}
+
+impl ToRedisArgs for TsAggregationOptions {
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        self.aggregator.write_redis_args(out);
+
+        if let Some(bt) = &self.bucket_timestamp {
+            bt.write_redis_args(out);
+        }
+
+        if self.empty {
+            out.write_arg(b"EMPTY");
+        }
+    }
+}
+
+// a trait to allow both TsAggregationType and TsAggregationOptions to be passed as aggregation options
+pub trait Aggregateable {}
+
+impl Aggregateable for TsAggregationType {}
+impl Aggregateable for TsAggregationOptions {}
+
+
 /// Different options for handling inserts of duplicate values. Block
 /// is the behaviour redis time series was using before preventing all
-/// inserts of values older or equal to latest value in series. Fist
+/// inserts of values older or equal to latest value in series. First
 /// will simply ignore the new value (as opposed to returning an error),
 /// Last will use the new value, Min the lower and Max the higher value.
 #[derive(PartialEq, Eq, Clone, Debug)]


### PR DESCRIPTION
This pull request adds support to the new aggregation options introduced in RedisTimeSeries 1.8: 
EMPTY - retrieves empty gaps from a timeseries
BUCKETTIMESTAMP - controls how bucket timestamps are reported

The PR introduces a new interface `TsAggregationOptions` made idiomatic to the existing library interfaces such as `TsOptions`.
The `TsAggregationOptions` can be passed to all the range functions as an alternative to `TsAggregationType` and it contains a `TsAggregationType`, an optional `TsBucketTimestamp`, and `empty` flag to denote the new aggregation features.

Additionally, minimal testing was added to check the basic use of the features.
In terms of backward compatibility, `TsAggregationType` can still be passed as an aggregation argument to the range functions, however, when aggregation is passed as None, an explicit type of `Aggregatable` needs to be passed (i.e `None::<TsAggregationOptions>` or `None::<TsAggregationType>`)

Finally, an example to illustrate the change in the interface:
```rust
// old
let first_three_avg:TsRange<u64,f64> = con.ts_range(
    "my_engine", "-", "+", Some(3), Some(TsAggregationType::Avg(5000))
)?;

// new
let first_three_avg_empty_bucket_mid:TsRange<u64,f64> = con.ts_range(
    "my_engine", "-", "+", Some(3), Some(
            TsAggregationOptions::new(TsAggregationType::Avg(5000))
                .empty(true)
                .bucket_timestamp(Some(TsBucketTimestamp::Mid))
       ))?;
```