### PR TITLE
expose TsMrangeEntry to users

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,7 +352,7 @@ pub use crate::commands::TsCommands;
 
 pub use crate::types::{
     TsAggregationType, TsAlign, TsBucketTimestamp, TsDuplicatePolicy, TsFilterOptions, TsInfo,
-    TsMget, TsMrange, TsOptions, TsRange, TsRangeQuery,
+    TsMget, TsMrange, TsMrangeEntry, TsOptions, TsRange, TsRangeQuery,
 };
 
 #[cfg(any(feature = "tokio-comp", feature = "async-std-comp"))]


### PR DESCRIPTION
Not having the `TsMrangeEntry` exposed to users of the library makes it impossible to manually create instances of `TsMrange`. This makes testing difficult as the `TsMrange` cannot be mocked. To test functions that return something like `Vec<TsMrange<u64, f64>>` (an mrange from each shard in a cluster), you have to do something like change the return type to `Vec<Vec<Timeseries>>` where `Timeseries` is a new struct. Then you are forced to copy all the `TsMrangeEntry` values over to these new structs, which is a wildly unnecessary performance hit. 

I see that `TsMrangeEntry` is already `public` so I'm hoping someone simply forgot to add `pub use` it!