### PR TITLE
Bump redis to 0.25.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "redis_ts"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["protom <office@protom.eu>"]
 keywords = ["redis", "database"]
 description = "API for Redis time series types."
@@ -13,7 +13,7 @@ edition = "2018"
 exclude = ["docker"]
 
 [dependencies]
-redis = { version = "0.24.0", optional = true }
+redis = { version = "0.25.2", optional = true }
 
 [features]
 default = ['redis']

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # redis_ts
 
-[![crates.io](https://img.shields.io/badge/crates.io-v0.5.3-orange)](https://crates.io/crates/redis_ts)
+[![crates.io](https://img.shields.io/badge/crates.io-v0.5.4-orange)](https://crates.io/crates/redis_ts)
 ![Continuous integration](https://github.com/tompro/redis_ts/workflows/Continuous%20integration/badge.svg)
 
 redis_ts provides a small trait with extension functions for the 
@@ -10,13 +10,13 @@ a [redis module](https://oss.redislabs.com/redistimeseries). Time
 series commands are available as synchronous and asynchronous versions.
  
 The crate is called `redis_ts` and you can depend on it via cargo. You will 
-also need redis in your dependencies. It has been tested against redis 0.24.0 
+also need redis in your dependencies. It has been tested against redis 0.25.2 
 but should work with versions higher than that.
 
  ```ini
  [dependencies]
- redis = "0.24.0"
- redis_ts = "0.5.3"
+ redis = "0.25.2"
+ redis_ts = "0.5.4"
  ```
 
  Or via git:
@@ -30,8 +30,8 @@ With async feature inherited from the [redis](https://docs.rs/redis) crate (eith
 
 ```ini
  [dependencies]
- redis = "0.24.0"
- redis_ts = { version = "0.5.3", features = ['tokio-comp'] }
+ redis = "0.25.2"
+ redis_ts = { version = "0.5.4", features = ['tokio-comp'] }
 ``` 
  
  ## Synchronous usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,13 +5,13 @@
 //! series commands are available as synchronous and asynchronous versions.
 //!
 //! The crate is called `redis_ts` and you can depend on it via cargo. You will
-//! also need redis in your dependencies. It has been tested against redis 0.24.0
+//! also need redis in your dependencies. It has been tested against redis 0.25.2
 //! but should work with versions higher than that.
 //!
 //! ```ini
 //! [dependencies]
-//! redis = "0.24.0"
-//! redis_ts = "0.5.3"
+//! redis = "0.25.2"
+//! redis_ts = "0.5.4"
 //! ```
 //!
 //! Or via git:
@@ -25,8 +25,8 @@
 //! crate (either: 'async-std-comp' or 'tokio-comp):
 //! ```ini
 //! [dependencies]
-//! redis = "0.24.0"
-//! redis_ts = { version = "0.5.3", features = ['tokio-comp'] }
+//! redis = "0.25.2"
+//! redis_ts = { version = "0.5.4", features = ['tokio-comp'] }
 //! ```
 //!
 //! # Synchronous usage


### PR DESCRIPTION
I need redis-rs/redis-rs#1035 so my threads stop unrecoverably panicking when one of my shards is murdered 